### PR TITLE
include 0/negative values

### DIFF
--- a/d3viz.html
+++ b/d3viz.html
@@ -191,7 +191,6 @@
 
             for (idx in to_plot) {
               if (!d.hasOwnProperty(to_plot[idx])) return false;
-              if (raw(to_plot[idx])(d) <= 0) return false;
             }
             return true;
           });


### PR DESCRIPTION
From sanitize function, remove the line that drops 0 and negative values. This will fix charts for retry, bad, dbm_antsignal, and dbm_antnoise.
