### PR TITLE
Select on click

### DIFF
--- a/d3viz.html
+++ b/d3viz.html
@@ -495,35 +495,33 @@
         }
 
         function select_stream(streamId) {
-                // unselect all legends
-                d3.selectAll(".legend").classed("selected", false);
-                // unselect all points
-                d3.selectAll(".points").attr("fill", "grey")
-                console.log(selected_stream, streamId)
+          // unselect all legends
+          d3.selectAll(".legend").classed("selected", false);
+          // unselect all points
+          d3.selectAll(".points").attr("fill", "grey")
 
-                // if new stream selected, update view & selected stream
-                if (!selected_stream || streamId != to_valid_selector_id(selected_stream.key)){
-                  // select current legend
-                  d3.select('#legend_' + streamId).classed("selected", true);
-                  // select these points
-                  for (idx in to_plot){ 
-                    d3.selectAll('#pcap_vs_' + to_plot[idx] + '_' + streamId).attr("fill", "red")
-                  }
-                  // update selected_stream key/value pair
-                  for (idx in stream2packets) {
-                    if (to_valid_selector_id(stream2packets[idx].key) == streamId) {
-                      // set selected_stream so that it's locked to that stream when mousing over
-                      butter_bar('Locked down to ' + stream2packets[idx]);
-                      selected_stream = stream2packets[idx];
-                    break;
-                    }
-                  }
-                } else {
-                  selected_stream = null;
-                  butter_bar('Unlocked')
-                }
+          // if new stream selected, update view & selected stream
+          if (!selected_stream || streamId != to_valid_selector_id(selected_stream.key)){
+            // select current legend
+            d3.select('#legend_' + streamId).classed("selected", true);
+            // select these points
+            for (idx in to_plot){ 
+              d3.selectAll('#pcap_vs_' + to_plot[idx] + '_' + streamId).attr("fill", "red")
+            }
+            // update selected_stream key/value pair
+            for (idx in stream2packets) {
+              if (to_valid_selector_id(stream2packets[idx].key) == streamId) {
+                // set selected_stream so that it's locked to that stream when mousing over
+                butter_bar('Locked down to ' + stream2packets[idx]);
+                selected_stream = stream2packets[idx];
+                break;
+              }
+            }
+          } else {
+            selected_stream = null;
+            butter_bar('Unlocked')
+          }
         }
-
 
       </script>
 

--- a/d3viz.html
+++ b/d3viz.html
@@ -427,7 +427,7 @@
           pcap_secs = scales['pcap_secs'].invert(x);
           search_in = dataset;
 
-          // zan - to do - replace this functionality
+          // this mouseover to a particular stream - will maintain functionality for now
           if (selected_stream) {
             search_in = selected_stream.values;
           }

--- a/d3viz.html
+++ b/d3viz.html
@@ -5,9 +5,14 @@
     <style>
 
     .legend {
+      fill: gray;
       font-size: 14px;
-      font-weight: bold;
       text-anchor: left;
+    }
+
+    .selected {
+      font-weight: bold;
+      fill: red;
     }
 
     </style>
@@ -27,7 +32,7 @@
         // of Paint methods take up to half a second (see TimelineRawData-20150107T133507
         // in sandbox/)
 
-        var debug = true;
+        var debug = false;
         function log(o) {
           if (debug) {
             console.log(o);
@@ -44,11 +49,6 @@
         var width;  // of a plot
         var height; // of a plot
         var padding = 20;
-
-        // TODO(katepek): Pull in some standard library for this
-        var stream_colours =
-          ['grey', 'red', 'blue', 'green', 'magenta',
-           'black', 'hotpink', 'chocolate', 'deepskyblue', 'gold'];
 
         var field_settings = {
           'pcap_secs': {
@@ -146,6 +146,7 @@
             return raw('pcap_secs')(x) - raw('pcap_secs')(y);
           });
 
+          // zan: todo - make this a dictionary? 
           stream2packets = d3.nest()
             .key(function(d) {return to_stream_key(d);})
             .sortKeys(function(key1, key2) {
@@ -267,34 +268,11 @@
               .attr('x', col * total_length + 2 * padding)
               .attr('y', (row + 1.5) * padding)
               .attr('class', 'legend')
-              .style('fill', get_colour(i))
               .text(d.key)
               .on('click', function(){
-                set_selected_stream(d);
+                select_stream(this.id.match(/legend_(.*)/)[1]);
             });
           });
-        }
-
-        function set_selected_stream(stream) {
-          if (selected_stream != null) {
-            d3.select('text#legend_' + to_valid_selector_id(selected_stream.key))
-              .transition().style('font-size', 16);
-          }
-          if (stream && selected_stream &&
-            stream.key == selected_stream.key) {
-            stream = null;
-          }
-          if (stream) {
-            d3.select('text#legend_' + to_valid_selector_id(stream.key))
-              .transition().style('font-size', 22);
-          }
-          selected_stream = stream;
-
-          if (selected_stream) {
-            butter_bar('Locked down to ' + selected_stream.key);
-          } else {
-            butter_bar('Not locked');
-          }
         }
 
         function butter_bar(text) {
@@ -330,7 +308,6 @@
 
           stream2packets.forEach(function(d, i) {
             current_plot_id = 'pcap_vs_' + field + '_' + to_valid_selector_id(d.key);
-            log(current_plot_id + ' (' + get_colour(i) + ')');
             log(d.key + "(" + d.values.length + ")");
 
             svg
@@ -338,10 +315,11 @@
               .data(d.values)
               .enter()
               .append('circle')
+              .attr('class', 'points')
               .attr('cx', scaled('pcap_secs'))
               .attr('cy', scaled(field))
+              .attr('fill', 'grey')
               .attr('r', 2)
-              .attr('fill', get_colour(i))
               .attr('id', current_plot_id);
           });
 
@@ -424,17 +402,9 @@
                 }
               })
               .on('click', function() {
-                set_selected_stream(null);
                 d = find_packet(d3.mouse(this)[0], d3.mouse(this)[1], field);
                 if (!d) return;
-
-                for (idx in stream2packets) {
-                  if (stream2packets[idx].key == to_stream_key(d)) {
-                    set_selected_stream(stream2packets[idx]);
-                    break;
-                  }
-                }
-
+                select_stream(to_valid_selector_id(to_stream_key(d)));
                 draw_crosshairs(d, field);
               })
               .on('mousemove', function() {
@@ -442,12 +412,6 @@
                 if (!d) return;
                 draw_crosshairs(d, field);
               });
-        }
-
-        function get_colour(i) {
-          if (i < stream_colours.length)
-            return stream_colours[i];
-          return stream_colours[i % stream_colours.length];
         }
 
         function binary_search_by(field) {
@@ -463,6 +427,7 @@
           pcap_secs = scales['pcap_secs'].invert(x);
           search_in = dataset;
 
+          // zan - to do - replace this functionality
           if (selected_stream) {
             search_in = selected_stream.values;
           }
@@ -528,6 +493,37 @@
                 '; ' + r_field + '=' + d[r_field]);
           }
         }
+
+        function select_stream(streamId) {
+                // unselect all legends
+                d3.selectAll(".legend").classed("selected", false);
+                // unselect all points
+                d3.selectAll(".points").attr("fill", "grey")
+                console.log(selected_stream, streamId)
+
+                // if new stream selected, update view & selected stream
+                if (!selected_stream || streamId != to_valid_selector_id(selected_stream.key)){
+                  // select current legend
+                  d3.select('#legend_' + streamId).classed("selected", true);
+                  // select these points
+                  for (idx in to_plot){ 
+                    d3.selectAll('#pcap_vs_' + to_plot[idx] + '_' + streamId).attr("fill", "red")
+                  }
+                  // update selected_stream key/value pair
+                  for (idx in stream2packets) {
+                    if (to_valid_selector_id(stream2packets[idx].key) == streamId) {
+                      // set selected_stream so that it's locked to that stream when mousing over
+                      butter_bar('Locked down to ' + stream2packets[idx]);
+                      selected_stream = stream2packets[idx];
+                    break;
+                    }
+                  }
+                } else {
+                  selected_stream = null;
+                  butter_bar('Unlocked')
+                }
+        }
+
 
       </script>
 


### PR DESCRIPTION
A few related changes throughout the document in order to: 

(1) switch from 20 colors to instead use default grey color.
(2) implement stream selection.  Streams can be selected by clicking on the legend or on any of the points in the charts.  This will turn red all points and the text in the legend associated with that stream.  

Note - there was an existing "locking" functionality for selected stream.  I coded the new selection to include this functionality.  The locking can be quite nice for following a stream when mousing over.  But, it could be frustrating to have to unselect the current stream in order to select a different stream's points (you can do this from the legend, just not from the points).  
